### PR TITLE
Fix: Template/section import fails

### DIFF
--- a/includes/wpzoom-template-manager.php
+++ b/includes/wpzoom-template-manager.php
@@ -558,6 +558,4 @@ if ( !class_exists( 'WPZOOM_Elementor_Library_Manager' ) ) {
 	// Initialize the Elementor library
 	WPZOOM_Elementor_Library_Manager::init();
 
-	require __DIR__ . '/wpzoom-template-library.php';
-
 } // Make sure class doesn't already exist

--- a/wpzoom-elementor-addons.php
+++ b/wpzoom-elementor-addons.php
@@ -242,8 +242,9 @@ final class WPZOOM_Elementor_Addons {
 	 * @access public
 	 */
 	public function init() {
-		// Add Plugin actions
-		// Pro features are unlocked when WPZOOM Elementor Addons Pro plugin is active
+		// Load template library (import handler) only after Elementor has loaded,
+		// so WPZOOM_Library_Source is registered and get_content_from_elementor_export_file works.
+		require_once WPZOOM_EL_ADDONS_PATH . 'includes/wpzoom-template-library.php';
 	}
 
 


### PR DESCRIPTION
### Problem

Inserting a page or section from the WPZOOM library shows: "The template could not be imported. Please try again or get in touch with the WPZOOM team."

### Cause

[wpzoom-template-library.php](https://github.com/wpzoom/WPZOOM-Elementor-Addons/blob/master/includes/wpzoom-template-library.php) was required at the end of [wpzoom-template-manager.php](https://github.com/wpzoom/WPZOOM-Elementor-Addons/blob/master/includes/wpzoom-template-manager.php), which is loaded in the main plugin’s includes() before Elementor runs. When the file loaded, elementor/loaded had not fired, so the if ( did_action( 'elementor/loaded' ) ) check failed, WPZOOM_Library_Source was never instantiated, and the get_content_from_elementor_export_file AJAX action was never registered. The insert request had no handler and failed.

### Solution

Load the template library only after Elementor has loaded: require wpzoom-template-library.php in the main plugin’s init() (hooked to elementor/init) in wpzoom-elementor-addons.php.
Remove the early require: remove the require of wpzoom-template-library.php from the bottom of includes/wpzoom-template-manager.php.
With this order, the class and AJAX handler are registered correctly and template/section insert works.

### Files changed

[wpzoom-elementor-addons.php](https://github.com/wpzoom/WPZOOM-Elementor-Addons/blob/master/wpzoom-elementor-addons.php) – add require_once in init().
[includes/wpzoom-template-manager.php](https://github.com/wpzoom/WPZOOM-Elementor-Addons/blob/master/includes/wpzoom-template-manager.php) – remove require of template library at end of file.