### PR TITLE
fix: apply image border radius & margin in Layout 8 (Overlay)

### DIFF
--- a/includes/widgets/posts-grid/posts-grid.php
+++ b/includes/widgets/posts-grid/posts-grid.php
@@ -907,7 +907,7 @@ class Posts_Grid extends Widget_Base {
 				'type'       => Controls_Manager::DIMENSIONS,
 				'size_units' => [ 'px', '%' ],
 				'selectors'  => [
-					'{{WRAPPER}} .post-grid-inner .post-grid-thumbnail img' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};'
+					'{{WRAPPER}} .post-grid-thumbnail img' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};'
 				]
 			]
 		);
@@ -919,7 +919,7 @@ class Posts_Grid extends Widget_Base {
 				'type'       => Controls_Manager::DIMENSIONS,
 				'size_units' => [ 'px' ],
 				'selectors'  => [
-					'{{WRAPPER}} .post-grid-inner .post-grid-thumbnail' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};'
+					'{{WRAPPER}} .post-grid-thumbnail' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};'
 				]
 			]
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author URI:        https://www.wpzoom.com/
 Requires at least: 6.5
 Requires PHP:      7.4
 Tested up to:      7.0
-Stable tag:        1.4.8
+Stable tag:        1.4.9
 License:           GNU General Public License v2
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 Tags:              elementor, elementor templates, starter templates, elementor widgets, elementor addons
@@ -127,6 +127,9 @@ No. The plugin only adds templates and widgets to the Elementor editor. It does 
 
 
 == Changelog ==
+
+= 1.4.9 =
+* FIX: Posts Grid widget - Image Border Radius and Margin settings now apply in Layout 8 (Overlay)
 
 = 1.4.8 =
 * Improvements to the Image Slider widget

--- a/wpzoom-elementor-addons.php
+++ b/wpzoom-elementor-addons.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Elementor Addons by WPZOOM
  * Plugin URI:        https://www.wpzoom.com/plugins/wpzoom-elementor-addons/
  * Description:       A plugin that provides a collection of Elementor Templates and advanced widgets created by the WPZOOM team
- * Version:           1.4.8
+ * Version:           1.4.9
  * Author:            WPZOOM
  * Author URI:        https://www.wpzoom.com/
  * Text Domain:       wpzoom-elementor-addons


### PR DESCRIPTION
Fix: #12

---

The Image style controls (Border Radius, Margin) targeted `.post-grid-inner .post-grid-thumbnail`, but Layout 8 (Overlay) renders the thumbnail without a `.post-grid-inner wrapper`, so the styles never matched.

This PR removes the `.post-grid-inner` prefix so the controls apply across all layouts. No regression for Layouts 1–7 since {{WRAPPER}} already outranks the base frontend.css rules.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/a863addc-43c0-484d-b9de-dad414b0b83a" />
